### PR TITLE
Add POST /players route tests with Mockk

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -4,6 +4,7 @@ val kotlin_version: String by project
 val logback_version: String by project
 val hikari_version: String by project
 val ktor_version: String by project
+val mockk_version: String by project
 
 plugins {
     kotlin("jvm") version "2.3.0"
@@ -51,6 +52,7 @@ dependencies {
     implementation("io.ktor:ktor-server-config-yaml")
     testImplementation("io.ktor:ktor-server-test-host")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version")
+    testImplementation("io.mockk:mockk:$mockk_version")
     implementation("com.zaxxer:HikariCP:${hikari_version}")
     implementation("io.github.cdimascio:dotenv-kotlin:6.4.1")
     implementation("org.postgresql:postgresql:42.7.4")

--- a/backend/gradle.properties
+++ b/backend/gradle.properties
@@ -5,3 +5,4 @@ kotlin_version=2.3.0
 ktor_version=3.4.2
 logback_version=1.4.14
 hikari_version=5.1.0
+mockk_version=1.13.17

--- a/backend/src/main/kotlin/features/player/PlayerService.kt
+++ b/backend/src/main/kotlin/features/player/PlayerService.kt
@@ -17,13 +17,13 @@ import com.brawlpulse.api.infrastructure.brawlhalla.models.PlayerStatsRanked
 import com.brawlpulse.api.infrastructure.brawlhalla.models.SearchPlayerResponse
 import io.ktor.client.plugins.HttpRequestTimeoutException
 
-class PlayerService(
+open class PlayerService(
     private val bhClient : BrawlhallaDao,
     private val playerRepository: PlayerRepository,
     private val dailySnapshotService: DailySnapshotsService
 ) {
 
-    suspend fun addPlayer(steamId : Long, apiKey: String) : AddPlayerResult {
+    open suspend fun addPlayer(steamId : Long, apiKey: String) : AddPlayerResult {
         var player : Player? = playerRepository.getPlayer(steamId)
         var addPlayerResult : AddPlayerResult
         if (player == null) {
@@ -60,7 +60,7 @@ class PlayerService(
         return addPlayerResult
     }
 
-    suspend fun deletePlayer(steamId : Long) : DeletePlayerResult {
+    open suspend fun deletePlayer(steamId : Long) : DeletePlayerResult {
         val isRemoved = playerRepository.deletePlayer(steamId)
         return if (isRemoved) {
             DeletePlayerResult.Removed

--- a/backend/src/test/kotlin/features/player/PlayerRoutesTest.kt
+++ b/backend/src/test/kotlin/features/player/PlayerRoutesTest.kt
@@ -1,0 +1,115 @@
+package com.brawlpulse.api.features.player
+
+import com.brawlpulse.api.features.player.exceptions.BrawlhallaApiUnavailableException
+import com.brawlpulse.api.features.player.exceptions.SteamIdNotLinkedException
+import com.brawlpulse.api.features.player.result.AddPlayerResult
+import com.brawlpulse.api.plugins.configureSerialization
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.ktor.server.routing.*
+import io.ktor.server.testing.*
+import io.mockk.*
+import kotlinx.serialization.json.*
+import org.junit.Before
+import java.time.OffsetDateTime
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PlayerRoutesTest {
+
+    private val mockPlayerService = mockk<PlayerService>()
+    private val testApiKey = "test-api-key"
+
+    private val testPlayer = Player(
+        id = 1,
+        steamId = 76561198123456789L,
+        brawlhallaId = 123456,
+        currentName = "TestPlayer",
+        addedAt = OffsetDateTime.now()
+    )
+
+    @Before
+    fun setUp() {
+        clearMocks(mockPlayerService)
+    }
+
+    private fun ApplicationTestBuilder.setupRouting() {
+        application {
+            configureSerialization()
+            routing {
+                playerRoutes(mockPlayerService, testApiKey)
+            }
+        }
+    }
+
+    @Test
+    fun `POST players returns 201 Created when new player is added`() = testApplication {
+        setupRouting()
+        coEvery { mockPlayerService.addPlayer(testPlayer.steamId, testApiKey) } returns AddPlayerResult.Created(testPlayer)
+
+        val response = client.post("/players") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"steamId": ${testPlayer.steamId}}""")
+        }
+
+        assertEquals(HttpStatusCode.Created, response.status)
+        val body = Json.parseToJsonElement(response.bodyAsText()).jsonObject
+        assertEquals(testPlayer.steamId, body["steamId"]!!.jsonPrimitive.long)
+        assertEquals(testPlayer.brawlhallaId, body["brawlhallaId"]!!.jsonPrimitive.int)
+        assertEquals(testPlayer.currentName, body["currentName"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `POST players returns 200 OK when player is already tracked`() = testApplication {
+        setupRouting()
+        coEvery { mockPlayerService.addPlayer(testPlayer.steamId, testApiKey) } returns AddPlayerResult.AlreadyTracked(testPlayer)
+
+        val response = client.post("/players") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"steamId": ${testPlayer.steamId}}""")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = Json.parseToJsonElement(response.bodyAsText()).jsonObject
+        assertEquals(testPlayer.steamId, body["steamId"]!!.jsonPrimitive.long)
+    }
+
+    @Test
+    fun `POST players returns 404 when steamId is not linked to Brawlhalla`() = testApplication {
+        setupRouting()
+        coEvery { mockPlayerService.addPlayer(any(), testApiKey) } throws SteamIdNotLinkedException("SteamId not linked")
+
+        val response = client.post("/players") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"steamId": 99999999999}""")
+        }
+
+        assertEquals(HttpStatusCode.NotFound, response.status)
+    }
+
+    @Test
+    fun `POST players returns 503 when Brawlhalla API is unavailable`() = testApplication {
+        setupRouting()
+        coEvery { mockPlayerService.addPlayer(any(), testApiKey) } throws BrawlhallaApiUnavailableException("API unavailable")
+
+        val response = client.post("/players") {
+            contentType(ContentType.Application.Json)
+            setBody("""{"steamId": 12345678901}""")
+        }
+
+        assertEquals(HttpStatusCode.ServiceUnavailable, response.status)
+    }
+
+    @Test
+    fun `POST players returns 400 when request body is missing steamId`() = testApplication {
+        setupRouting()
+
+        val response = client.post("/players") {
+            contentType(ContentType.Application.Json)
+            setBody("{}")
+        }
+
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+    }
+}


### PR DESCRIPTION
- Add Mockk 1.13.17 test dependency
- Make PlayerService open to enable subclass-based mocking
- Add PlayerRoutesTest covering: 201 Created (new player), 200 OK (already tracked), 404 (steamId not linked), 503 (API unavailable), 400 (missing steamId in body)